### PR TITLE
Add option for non-exact regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
-module.exports = function () {
+module.exports = function (opts) {
+  var exact = (opts && opts.exact !== undefined) ? opts.exact : true;
   var ip = '(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])(?:\\.(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])){3}';
   var protocol = '(?:http(s?)\:\/\/)?';
   var auth = '(?:\\S+(?::\\S*)?@)?';
@@ -11,5 +12,5 @@ module.exports = function () {
   var path = '(?:[/?#][^\\s"]*)?';
   var regex = '(?:' + protocol + '|www\\.)' + auth + '(?:localhost|' + ip + '|' + host + domain + tld + ')' + port + path;
 
-  return new RegExp('(?:^' + regex + '$)', 'i');
+  return exact ? new RegExp('(?:^' + regex + '$)', 'i') : new RegExp(regex, 'ig');
 };

--- a/test/urlmatch.js
+++ b/test/urlmatch.js
@@ -1,7 +1,7 @@
 const tap = require('tap');
 const regex = require('../index.js');
 
-const fixtures = [
+const exactFixtures = [
   'http://foo.com/blah_blah',
   'http://foo.com/blah_blah/',
   'http://foo.com/blah_blah_(wikipedia)',
@@ -58,9 +58,19 @@ const fixtures = [
   'http://userid:password@example.com',
   'http://➡.ws/䨹',
   'www.google.com/unicorn',
-  'http://example.com.'
+  'http://example.com.',
 ];
 
-for (const x of fixtures) {
+const notExactFuxtures = [
+  'Some text http://example.com some other text',
+  'Some text \'http://1337.net\' some other text',
+  'Some text "http://foo.com/blah_blah/". some other text',
+]
+
+for (const x of exactFixtures) {
   tap.ok(regex().test(x), x);
+}
+
+for (const str of notExactFuxtures) {
+  tap.ok(regex({exact: false}).test(str), str);
 }


### PR DESCRIPTION
@nescalante I added non-exact option for regex to be consistent with initial url-regex package.

Now you can find links in strings like this: Some text "http://foo.com/blah_blah/". some other text

Left exact version as default not to break existing functionality