### PR TITLE
Add allowedProtocols option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,6 +16,9 @@ npm install urlregex
 const urlRegex = require('urlregex');
 const isValid = urlRegex().test('http://github.com');
 ```
+### `allowedProtocols` option
+
+You can provide the `allowedProtocols` option to specify which protocols are allowed in the URL. It can either be an array of strings or the `'*'` wildcard to allow any protocol.
 
 ## Credits
 

--- a/main.js
+++ b/main.js
@@ -6,11 +6,16 @@ module.exports = function (RE) {
     var tldvalidation = opts && opts.tld !== undefined ? opts.tld : true;
     var allowWebSockets =
       opts && opts.allowWebSockets !== undefined ? opts.allowWebSockets : false;
+    var allowedProtocols =
+      opts && opts.allowedProtocols !== undefined ? opts.allowedProtocols : ['http', 'https'];
+
+    if (allowedProtocols  !== '*' && allowWebSockets) {
+      allowedProtocols = allowedProtocols.concat('ws', 'wss');
+    }
+
     var ip =
       '(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])(?:\\.(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])){3}';
-    var protocol = allowWebSockets
-      ? '(?:(http|ws)(s?)://)?'
-      : '(?:http(s?)://)?';
+    var protocol = allowedProtocols === '*' ? '(?:(?:[a-z]+:)?//)?' : '(?:('+ allowedProtocols.join('|') +')://)?';
     var auth = '(?:\\S+(?::\\S*)?@)?';
     var host = '(?:(?:[a-z\\u00a1-\\uffff0-9_]-*)*[a-z\\u00a1-\\uffff0-9]+)';
     var domain =

--- a/test/notmatch.js
+++ b/test/notmatch.js
@@ -1,7 +1,7 @@
 const tap = require('tap');
 const regex = require('../server.js');
 
-const fixtures = [
+const defaultOptsFixture = [
   'http://',
   'http://.',
   'http://..',
@@ -44,6 +44,21 @@ const fixtures = [
   'http://www.example.xn--overly-long-punycode-test-string-test-tests-123-test-test123/',
 ];
 
-for (const x of fixtures) {
+const allowedProtocolsFixture = [
+  'httpsss://carlitos.tevez',
+  'amp://elsultan.volvio.aladrar',
+  'miau://haha.com',
+  '://jaja.com'
+];
+
+for (const x of defaultOptsFixture) {
   tap.equal(regex().test(x), false, x);
+}
+
+for (const x of allowedProtocolsFixture) {
+  tap.equal(
+    regex({ allowedProtocols: ['https', 'amqp', 'guau'] }).test(x),
+    false,
+    x
+  );
 }

--- a/test/notmatch.js
+++ b/test/notmatch.js
@@ -46,6 +46,7 @@ const defaultOptsFixture = [
 
 const allowedProtocolsFixture = [
   'httpsss://carlitos.tevez',
+  'http://carlitos.tevez',
   'amp://elsultan.volvio.aladrar',
   'miau://haha.com',
   '://jaja.com'

--- a/test/urlmatch.js
+++ b/test/urlmatch.js
@@ -79,6 +79,11 @@ const noTldValidationFixtures = [
 
 const webSocketsFixtures = ['ws://example.com', 'wss://example.com'];
 
+const allowedProtocolFixtures = ['https://something.com', 'amqp://cacho.com', 'about://posta.com', 'ipn://asi.si']
+const allowedProtocolWithWebSocketFlagFixtures = ['https://something.com', 'amqp://cacho.com', 'wss://websocke.com', 'ws://professsssiona.com'];
+const allowedProtocolWithTldFalseFixtures = ['https://something', 'amqp://cacho', 'loquede://a100meduermo']
+const anyProtocolFixtures = ['https://something.com', 'amqp://asd.com', 'newprotocolintheworld://hi.com', 'yes.com'];
+
 for (const x of exactFixtures) {
   tap.ok(regex().test(x), x);
 }
@@ -93,4 +98,24 @@ for (const x of noTldValidationFixtures) {
 
 for (const x of webSocketsFixtures) {
   tap.ok(regex({ allowWebSockets: true }).test(x), x);
+}
+
+for (const x of allowedProtocolFixtures) {
+  tap.ok(regex({ allowedProtocols: ['https', 'amqp', 'about', 'ipn'] }).test(x), x)
+}
+
+for (const x of allowedProtocolWithWebSocketFlagFixtures) {
+  tap.ok(regex({ allowedProtocols: ['https', 'amqp'], allowWebSockets: true }).test(x), x)
+}
+
+for (const x of allowedProtocolWithWebSocketFlagFixtures) {
+  tap.ok(regex({ allowedProtocols: ['https', 'amqp'], allowWebSockets: true }).test(x), x)
+}
+
+for (const x of allowedProtocolWithTldFalseFixtures) {
+  tap.ok(regex({ allowedProtocols: ['https', 'amqp', 'loquede'], tld: false }).test(x), x)
+}
+
+for (const x of anyProtocolFixtures) {
+  tap.ok(regex({ allowedProtocols: '*' }).test(x), x)
 }


### PR DESCRIPTION
- Add allowedProtocols option in order to specify what protocols should be used in the regexp. 
- If '*' is passed, allow any protocol
- Update readme
- Note: The change is backwards compatible with allowWebSockets.